### PR TITLE
refactor promises

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,12 @@ var mkdirp = require("mkdirp");
 var ROOT = process_1.cwd();
 /* From args */
 function compileAndDeploy(opts) {
-    return new Promise(function (resolve, reject) {
+    return Promise.resolve().then(function () {
         /* TODO: Handle missing opts */
         var code = fs.readFileSync(ROOT + opts.file, 'utf8'); //TODO: don't assume UTF-8
         var src = { code: code, name: opts.name };
         var output = {};
-        eth_utils.compile(src).then(function (compiled) {
+        return eth_utils.compile(src).then(function (compiled) {
             for (var contract in compiled) {
                 output[contract] = {
                     abi: compiled[contract].abi,
@@ -24,9 +24,7 @@ function compileAndDeploy(opts) {
         }).then(function (deployed) {
             output[opts.name].address = deployed.address;
             output[opts.name].txHash = deployed.txHash;
-            resolve(output);
-        })["catch"](function (err) {
-            console.log(err); //TODO: Handle error better
+            return output;
         });
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const ROOT = cwd();
 
 /* From args */
 export function compileAndDeploy(opts: DeployOpts): Promise<Output> {
-  return new Promise((resolve, reject) => {
+  return Promise.resolve().then(() => {
     /* TODO: Handle missing opts */
 
     const code = fs.readFileSync(ROOT + opts.file, 'utf8'); //TODO: don't assume UTF-8
@@ -17,7 +17,7 @@ export function compileAndDeploy(opts: DeployOpts): Promise<Output> {
 
     const output = {};
 
-    eth_utils.compile(src).then((compiled) => {
+    return eth_utils.compile(src).then((compiled) => {
 
       for(var contract in compiled) {
         output[contract] = {
@@ -34,10 +34,7 @@ export function compileAndDeploy(opts: DeployOpts): Promise<Output> {
       output[opts.name].address = deployed.address;
       output[opts.name].txHash = deployed.txHash;
 
-      resolve(output);
-
-    }).catch((err) => {
-      console.log(err); //TODO: Handle error better
+      return output;
     });
   });
 
@@ -59,9 +56,6 @@ export function writeOutput(path: string, output: Output) {
   if(!fs.existsSync(properPath)) {
     mkdirp.sync(properPath);
   }
-  
+
   fs.writeFileSync(properPath + '/contracts.json', JSON.stringify(output, null, '  '));
 }
-
-
-


### PR DESCRIPTION
- create only one chain of promises
- delegate error handling to the callee, otherwise errors are going to be swallowed by this library

refactored with a minimal git diff